### PR TITLE
Update to 1.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 # The latest versions are available at https://lambdaurora.dev/tools/import_quilt.html
-minecraft = "1.19.2"
-quilt_mappings = "1.19.2+build.21"
-quilt_loader = "0.17.5"
+minecraft = "1.20"
+quilt_mappings = "1.20+build.4"
+quilt_loader = "0.19.0-beta.18"
 
-quilted_fabric_api = "4.0.0-beta.17+0.64.0-1.19.2"
+quilted_fabric_api = "7.0.1+0.83.0-1.20"
 
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }

--- a/src/main/java/io/github/sweetberrycollective/block/SweetCropsBlocks.java
+++ b/src/main/java/io/github/sweetberrycollective/block/SweetCropsBlocks.java
@@ -2,8 +2,9 @@ package io.github.sweetberrycollective.block;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import org.quiltmc.qsl.block.extensions.api.QuiltBlockSettings;
 
 public class SweetCropsBlocks {
@@ -11,7 +12,7 @@ public class SweetCropsBlocks {
 	public static final MintBlock MINT = new MintBlock(QuiltBlockSettings.copy(Blocks.BEETROOTS));
 
 	public static void register(Block block, String id) {
-		Registry.register(Registry.BLOCK, new Identifier("sweet_crops", id), block);
+		Registry.register(Registries.BLOCK, new Identifier("sweet_crops", id), block);
 	}
 
 	public static void initialize() {

--- a/src/main/java/io/github/sweetberrycollective/item/SweetCropsItems.java
+++ b/src/main/java/io/github/sweetberrycollective/item/SweetCropsItems.java
@@ -4,8 +4,9 @@ import io.github.sweetberrycollective.block.SweetCropsBlocks;
 import net.minecraft.item.AliasedBlockItem;
 import net.minecraft.item.FoodComponents;
 import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import org.quiltmc.qsl.item.setting.api.QuiltItemSettings;
 
 public class SweetCropsItems {
@@ -14,7 +15,7 @@ public class SweetCropsItems {
 	public static final Item MINT_LEAF = new Item(new QuiltItemSettings().food(FoodComponents.BEETROOT));
 
 	public static void register(Item item, String id) {
-		Registry.register(Registry.ITEM, new Identifier("sweet_crops", id), item);
+		Registry.register(Registries.ITEM, new Identifier("sweet_crops", id), item);
 	}
 
 	public static void initialize() {


### PR DESCRIPTION
A quick direct port to Minecraft `1.20`
Didn't bother porting to `rc-1` because `.1` and `.0` are identical for the mod's purposes.

I'd directly pull this in myself but it's getting a bit late and I'm unsure of myself so I'm gonna leave it open for now, but I've tested and it works.